### PR TITLE
Adds missing `d` in and

### DIFF
--- a/markdown/posts/2019-07-22-project-generation.md
+++ b/markdown/posts/2019-07-22-project-generation.md
@@ -148,7 +148,7 @@ Using Swift over declarative formats like YAML makes it possible without having 
 
 ## 5 - Complexities
 
-One of the most important lessons that a developer can learn for coding is KISS *(keep it simple an stupid)*.
+One of the most important lessons that a developer can learn for coding is KISS *(keep it simple and stupid)*.
 I believe the same applies to Xcode projects.
 In this case,
 the complexity is hard to avoid because it's Xcode the one exposing it.


### PR DESCRIPTION
In the `Project generation` blogpost there's a typo in the `Complexities` paragraph: https://ppinera.es/2019/07/22/project-generation/?utm_campaign=iOS%2BDev%2BWeekly&utm_medium=email&utm_source=iOS%2BDev%2BWeekly%2BIssue%2B415#5---complexities

I think a `d` is missing 